### PR TITLE
Add new features to `unstable-api` tool.

### DIFF
--- a/tools/unstable-api/Cargo.toml
+++ b/tools/unstable-api/Cargo.toml
@@ -19,3 +19,6 @@ version = "0.3"
 
 [dependencies.anyhow]
 version = "1"
+
+[target.'cfg(unix)'.dependencies]
+nix = "0.20"

--- a/tools/unstable-api/README.md
+++ b/tools/unstable-api/README.md
@@ -7,7 +7,7 @@ This tool will dump the public API for an unstable feature.
 From this directory, run something like:
 
 ```shell
-cargo run --release -- --feature $feature --repo-root $path_to_rust | rustfmt
+cargo run --release -- --feature $feature --repo-root $path_to_rust
 ```
 
 where `$feature` is the name of the unstable feature and `$path_to_rust` is the path to a local clone of `rust-lang/rust`. You'll probably need to run `x.py` first to make sure submodules are cloned.
@@ -16,8 +16,15 @@ You can also install it as a Cargo tool and use it that way:
 
 ```shell
 cargo install --path .
-cargo unstable-api --feature $feature --repo-root $path_to_rust | rustfmt
+cd $path_to_rust
+cargo unstable-api --feature $feature
 ```
+
+You can leave out the `--repo-root` option when running it inside the `rust-lang/rust` repository.
+
+## Output formatting
+
+On Unix, the output is automatically formatted with `rustfmt` and highlighted with `bat`, if you have those tools installed.
 
 ## Limitations
 

--- a/tools/unstable-api/src/main.rs
+++ b/tools/unstable-api/src/main.rs
@@ -27,6 +27,9 @@ fn main() -> Result<(), Error> {
         None => find_repo_root()?,
     };
 
+    #[cfg(unix)]
+    setup_output_formatting();
+
     let libs = vec![
         repo_root.clone().join("library/core"),
         repo_root.clone().join("library/alloc"),
@@ -51,4 +54,35 @@ fn find_repo_root() -> Result<PathBuf, Error> {
     let mut path = PathBuf::from(String::from_utf8(path)?);
     path.pop();
     Ok(path)
+}
+
+#[cfg(unix)]
+fn setup_output_formatting() {
+    use nix::unistd::{isatty, dup2};
+    use std::os::unix::io::AsRawFd;
+    use std::process::{Command, Stdio};
+
+    if isatty(1) == Ok(true) {
+        // Pipe the output through `bat` for nice formatting and paging, if available.
+        if let Ok(mut bat) = Command::new("bat")
+            .arg("--language=rust")
+            .arg("--plain") // Disable line numbers for easy copy-pasting.
+            .stdin(Stdio::piped())
+            .stdout(Stdio::inherit())
+            .spawn()
+        {
+            // Replace our stdout by the pipe into `bat`.
+            dup2(bat.stdin.take().unwrap().as_raw_fd(), 1).unwrap();
+        }
+    }
+
+    // Pipe the output through `rustfmt`, if available.
+    if let Ok(mut rustfmt) = Command::new("rustfmt")
+        .stdin(Stdio::piped())
+        .stdout(Stdio::inherit()) // This pipes into `bat` if it was executed above.
+        .spawn()
+    {
+        // Replace our stdout by the pipe into `rustfmt`.
+        dup2(rustfmt.stdin.take().unwrap().as_raw_fd(), 1).unwrap();
+    }
 }


### PR DESCRIPTION
With this change:
1. It uses `cargo locate-project --workspace` to find the `--repo-root` automatically, so you can just run `cargo unstable-api` inside the rust repository.
2. It automatically pipes the output through `rustfmt` and `bat`. (This only works on `cfg(unix)`.)