### PR TITLE
Simplify output of the `unstable-api` tool a bit.

### DIFF
--- a/tools/unstable-api/src/util.rs
+++ b/tools/unstable-api/src/util.rs
@@ -17,15 +17,18 @@ pub(crate) fn lit_is_str(lit: &syn::Lit, s: &str) -> bool {
 pub(crate) fn empty_block() -> syn::Block {
     syn::Block {
         brace_token: Default::default(),
-        stmts: Default::default(),
+        stmts: vec![syn::Stmt::Expr(empty_expr())],
     }
 }
 
 pub(crate) fn empty_expr() -> syn::Expr {
-    syn::ExprBlock {
-        attrs: vec![],
-        label: None,
-        block: empty_block(),
+    // This is just a `..` token, which is technically a valid expression,
+    // but looks like a placeholder.
+    syn::ExprRange {
+        attrs: Vec::new(),
+        from: None,
+        to: None,
+        limits: syn::RangeLimits::HalfOpen(Default::default()),
     }
     .into()
 }


### PR DESCRIPTION
This makes two changes:

1: It uses `..` instead of `{}` for removed expressions, and `{ .. }` instead of `{}` for removed blocks:

Before:
```rust
    pub const A: usize = {};

    pub fn a() -> usize {}
```
After:
```rust
    pub const A: usize = ..;

    pub fn a() -> usize { .. }
```

2: It no longer prints any of the methods and constants inside a `impl Trait for Type { .. }` block, as those are not relevant for stability.

Before:
```rust
    impl fmt::Display for Thing {
        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {}
    }
```
After:
```rust
    impl fmt::Display for Thing {}
```