### PR TITLE
Add exclude_labels method to GithubQuery

### DIFF
--- a/tools/agenda-generator/Cargo.toml
+++ b/tools/agenda-generator/Cargo.toml
@@ -5,10 +5,10 @@ authors = ["Mara Bos <m-ou.se@m-ou.se>"]
 edition = "2018"
 
 [dependencies]
-anyhow = "1.0"
 chrono = { version = "0.4", features = ["serde"] }
 reqwest = { version = "0.10", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 itertools = "0.10.1"
 structopt = "0.3.21"
+color-eyre = "0.5.11"

--- a/tools/agenda-generator/src/generator.rs
+++ b/tools/agenda-generator/src/generator.rs
@@ -509,20 +509,12 @@ impl GithubQuery {
                 let issues = github_api(&endpoint)?;
                 let issues = generator.dedup(issues);
 
-                let excluded_labels: BTreeSet<_> = self
-                    .excluded_labels
-                    .iter()
-                    .flat_map(|labels| labels.iter())
-                    .map(|s| s.to_string())
-                    .collect();
                 let issues = issues.filter(|issue| {
-                    for excluded_label in &excluded_labels {
-                        if issue.labels.contains(&excluded_label) {
-                            return false;
-                        }
-                    }
-
-                    true
+                    !self.excluded_labels.iter().any(|labels| {
+                        labels
+                            .iter()
+                            .all(|&label| issue.labels.iter().any(|x| x == label))
+                    })
                 });
 
                 let issues: Vec<_> = if let Some(count) = self.count {

--- a/tools/agenda-generator/src/main.rs
+++ b/tools/agenda-generator/src/main.rs
@@ -1,11 +1,12 @@
-use anyhow::Result;
 use cli::AgendaKind;
+use color_eyre::eyre;
 use generator::Generator;
 
 mod cli;
 mod generator;
 
-fn main() -> Result<()> {
+fn main() -> eyre::Result<()> {
+    color_eyre::install()?;
     let args = cli::Args::from_args();
     let generator = Generator::default();
     let agenda = match args.agenda {


### PR DESCRIPTION
closes https://github.com/rust-lang/libs-team/issues/31

This PR also adds some additional error reporting changes because I was annoyed by the error message the tool produces when you exceed the API limit

### Before

<pre>Error: error decoding response body: invalid type: map, expected a sequence at line 1 column 0

Caused by:
    invalid type: map, expected a sequence at line 1 column 0
</pre>

### After

<pre>Error: 
   0: <font color="#AB4642">response body cannot be deserialized</font>
   1: <font color="#AB4642">invalid type: map, expected a sequence at line 1 column 0</font>

Location:
   <font color="#BA8BAF">src/generator.rs</font>:<font color="#BA8BAF">617</font>

Response:
   {&quot;message&quot;:&quot;API rate limit exceeded for 76.126.15.40. (But here&apos;s the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)&quot;,&quot;documentation_url&quot;:&quot;https://docs.github.com/rest/overview/resources-in-the-rest-api#rate-limiting&quot;}


Backtrace omitted.
Run with RUST_BACKTRACE=1 environment variable to display it.
Run with RUST_BACKTRACE=full to include source snippets.

</pre>