### PR TITLE
add additional necessary info for triagebot

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-change-proposal.md
+++ b/.github/ISSUE_TEMPLATE/api-change-proposal.md
@@ -28,4 +28,6 @@ assignees: ""
 
 This issue is part of the libs-api team [API change proposal process]. Once this issue is filed the libs-api team will review open proposals in its weekly meeting. You should receive feedback within a week or two.
 
+**This issue is not meant to be used for technical discussion. There is a Zulip stream for that. Use this issue to leave procedural comments, such as volunteering to review, indicating that you second the proposal (or third, etc), or raising a concern that you would like to be addressed.**
+
 [API change proposal process]: https://std-dev-guide.rust-lang.org/feature-lifecycle/api-change-proposals.html

--- a/triagebot.toml
+++ b/triagebot.toml
@@ -2,5 +2,5 @@
 second_label = "initial-comment-period"
 meeting_label = "I-nominated"
 # can be found by looking for the first number in URLs, e.g. https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler
-# zulip_stream =
-# zulip_ping = "T-libs-api"
+zulip_stream = 327149
+zulip_ping = "T-libs-api"


### PR DESCRIPTION
from https://rust-lang.zulipchat.com/#narrow/stream/242791-t-infra/topic/ICP.20tooling.20support, turns out triagebot requires the zulip stream fields atm, added those for now and we can look into removing them later if we want.

