### PR TITLE
comment out malformed section of triagebot toml

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -1,6 +1,6 @@
-[major-change]
-second_label = "initial-comment-period"
-meeting_label = "I-nominated"
-# can be found by looking for the first number in URLs, e.g. https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler
+# [major-change]
+# second_label = "initial-comment-period"
+# meeting_label = "I-nominated"
+# # can be found by looking for the first number in URLs, e.g. https://rust-lang.zulipchat.com/#narrow/stream/131828-t-compiler
 # zulip_stream = 327149
 # zulip_ping = "T-libs-api"


### PR DESCRIPTION
fixes issue from https://github.com/rust-lang/libs-team/issues/51#issuecomment-1158020162

I'm leaving the toml file there for now because I'm hoping we will re-enable it sooner rather than later and it's slightly easier to uncomment it than to dig through the git history to revive it once it's deleted.