### PR TITLE
Further improvements to the change proposal template

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-change-proposal.md
+++ b/.github/ISSUE_TEMPLATE/api-change-proposal.md
@@ -14,7 +14,7 @@ assignees: ""
 
 ## Motivating examples or use cases
 
-<!-- Next add any motivating examples. Examples should ideally be real world examples, or minimized versions of the real world example in scenarios where the motivating code is not open source. -->
+<!-- Next add any motivating examples. Examples should ideally be real world examples, or minimized versions of the real world example in scenarios where the motivating code is not open source. Don't propose changes you think might *hypothetically* be useful; real use cases help make sure we have the right design. -->
 
 ## Solution sketch
 

--- a/.github/ISSUE_TEMPLATE/api-change-proposal.md
+++ b/.github/ISSUE_TEMPLATE/api-change-proposal.md
@@ -42,8 +42,14 @@ This issue is part of the libs-api team [API change proposal process]. Once this
 
 [API change proposal process]: https://std-dev-guide.rust-lang.org/feature-lifecycle/api-change-proposals.html
 
-Some common possible responses from the libs team:
+## Possible responses
 
-- We like this specific solution, approved, you or someone else should implement this.
-- We think this problem is worth solving, but we don't think the proposed solution is the right solution. Here are some hints that might help shape a better solution.
-- We don't think this should be part of the standard library. This doesn't mean the problem is unimportant, but not everything belongs in the standard library.
+The libs team may respond in various different ways. First, the team will consider the *problem* (this doesn't require any concrete solution or alternatives to have been proposed):
+
+- We think this problem seems worth solving, and the standard library might be the right place to solve it.
+- We think that this probably doesn't belong in the standard library.
+
+Second, if there's a concrete solution:
+
+- We think this specific solution looks roughly right, approved, you or someone else should implement this. (Further review will still happen on the subsequent implementation PR.)
+- We're not sure this is the right solution, and the alternatives or other materials don't give us enough information to be sure about that. Here are some questions we have that aren't answered, or rough ideas about alternatives we'd want to see discussed.

--- a/.github/ISSUE_TEMPLATE/api-change-proposal.md
+++ b/.github/ISSUE_TEMPLATE/api-change-proposal.md
@@ -21,7 +21,7 @@ assignees: ""
 <!--
 If you have a sketch of a concrete solution, please include it here. You don't have to have all the details worked out, but it should be enough to convey the idea.
 
-If you want to smoke-test whether some solution to the problem would be acceptable, you can delete this section.
+If you want to quickly check whether *any* some solution to the problem would be acceptable, you can delete this section.
 -->
 
 ## Alternatives

--- a/.github/ISSUE_TEMPLATE/api-change-proposal.md
+++ b/.github/ISSUE_TEMPLATE/api-change-proposal.md
@@ -41,3 +41,9 @@ Could this be written using existing APIs? If so, roughly what would that look l
 This issue is part of the libs-api team [API change proposal process]. Once this issue is filed the libs-api team will review open proposals as capability becomes available. Current response times do not have a clear estimate, but may be up to several months.
 
 [API change proposal process]: https://std-dev-guide.rust-lang.org/feature-lifecycle/api-change-proposals.html
+
+Some common possible responses from the libs team:
+
+- We like this specific solution, approved, you or someone else should implement this.
+- We think this problem is worth solving, but we don't think the proposed solution is the right solution. Here are some hints that might help shape a better solution.
+- We don't think this should be part of the standard library. This doesn't mean the problem is unimportant, but not everything belongs in the standard library.


### PR DESCRIPTION
- Tell people not to propose hypothetically useful APIs
- Give a more specific description than "smoke-test"
- List some common possible responses from the libs team
