### PR TITLE
Add change proposals to the libs-api agenda

### DIFF
--- a/tools/agenda-generator/src/generator.rs
+++ b/tools/agenda-generator/src/generator.rs
@@ -76,6 +76,20 @@ impl Generator {
             .repo("rust-lang/rust")
             .write(&mut self)?;
 
+        GithubQuery::new("New Change Proposals")
+            .labels(&["api-change-proposal"])
+            .repo("rust-lang/libs-team")
+            .sort(Sort::Newest)
+            .take(5)
+            .write(&mut self)?;
+
+        GithubQuery::new("Stalled Change Proposals")
+            .labels(&["api-change-proposal"])
+            .repo("rust-lang/libs-team")
+            .sort(Sort::LeastRecentlyUpdated)
+            .take(5)
+            .write(&mut self)?;
+
         GithubQuery::new("Stalled Tracking Issues")
             .labels(&["T-libs-api", "C-tracking-issue"])
             .repo("rust-lang/rust")


### PR DESCRIPTION
This adds the most recent 5 (to try to give a timely response to new
things), and the least recently updated 5 (to try to get through the
backlog). We don't have to solve all of them in any given meeting; the
ones we address will fall off the agenda.
