### PR TITLE
Resolve dead code warnings in agenda-generator

### DIFF
--- a/tools/agenda-generator/src/generator.rs
+++ b/tools/agenda-generator/src/generator.rs
@@ -524,7 +524,6 @@ impl GithubQuery {
     }
 
     fn write(&mut self, generator: &mut Generator) -> Result<()> {
-        let mut empty = true;
         for repo in &self.repos {
             for labels in &self.labels {
                 let cs_labels = labels.join(",");
@@ -589,19 +588,9 @@ impl GithubQuery {
     }
 }
 
-#[derive(Debug)]
-struct Fcp<'a> {
-    title: &'a str,
-    repo: &'a str,
-    number: &'a str,
-    disposition: &'a str,
-    url: &'a str,
-    reviewers: Vec<&'a str>,
-    concerns: bool,
-}
-
 #[derive(Debug, Deserialize)]
 struct Issue {
+    #[allow(dead_code)]
     number: u32,
     html_url: String,
     title: String,


### PR DESCRIPTION
```console
warning: unused variable: `empty`
   --> src/generator.rs:527:17
    |
527 |         let mut empty = true;
    |                 ^^^^^ help: if this is intentional, prefix it with an underscore: `_empty`
    |
    = note: `#[warn(unused_variables)]` on by default

warning: variable does not need to be mutable
   --> src/generator.rs:527:13
    |
527 |         let mut empty = true;
    |             ----^^^^^
    |             |
    |             help: remove this `mut`
    |
    = note: `#[warn(unused_mut)]` on by default

warning: multiple fields are never read
   --> src/generator.rs:594:5
    |
593 | struct Fcp<'a> {
    |        --- fields in this struct
594 |     title: &'a str,
    |     ^^^^^
595 |     repo: &'a str,
    |     ^^^^
596 |     number: &'a str,
    |     ^^^^^^
597 |     disposition: &'a str,
    |     ^^^^^^^^^^^
598 |     url: &'a str,
    |     ^^^
599 |     reviewers: Vec<&'a str>,
    |     ^^^^^^^^^
600 |     concerns: bool,
    |     ^^^^^^^^
    |
    = note: `Fcp` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
    = note: `#[warn(dead_code)]` on by default

warning: field `number` is never read
   --> src/generator.rs:605:5
    |
604 | struct Issue {
    |        ----- field in this struct
605 |     number: u32,
    |     ^^^^^^
    |
    = note: `Issue` has a derived impl for the trait `Debug`, but this is intentionally ignored during dead code analysis
```

`empty` used to be used prior to 3b4f88ae1db192d91f6fc50308d53cec7de4a3cc.

`Fcp` used to be used prior to #22.