### PR TITLE
Parse agenda-generator args using clap instead of structopt

### DIFF
--- a/tools/agenda-generator/Cargo.toml
+++ b/tools/agenda-generator/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
+clap = { version = "4", features = ["derive"] }
 color-eyre = "0.6"
 itertools = "0.12"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-structopt = "0.3.21"

--- a/tools/agenda-generator/Cargo.toml
+++ b/tools/agenda-generator/Cargo.toml
@@ -6,9 +6,9 @@ edition = "2018"
 
 [dependencies]
 chrono = { version = "0.4", features = ["serde"] }
+color-eyre = "0.6"
+itertools = "0.12"
 reqwest = { version = "0.11", features = ["blocking", "json"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
-itertools = "0.12"
 structopt = "0.3.21"
-color-eyre = "0.6"

--- a/tools/agenda-generator/src/cli.rs
+++ b/tools/agenda-generator/src/cli.rs
@@ -1,23 +1,21 @@
-use structopt::clap::arg_enum;
-use structopt::StructOpt;
+use clap::{Parser, ValueEnum};
 
-#[derive(Debug, StructOpt)]
+#[derive(Debug, Parser)]
 pub struct Args {
-    #[structopt(long, short, default_value = "LibsAPI", possible_values = &AgendaKind::variants())]
+    #[clap(long, short, default_value = "LibsAPI")]
     pub agenda: AgendaKind,
 }
 
 impl Args {
     pub fn from_args() -> Args {
-        StructOpt::from_args()
+        <Args as Parser>::parse()
     }
 }
 
-arg_enum! {
-    #[derive(Debug)]
-    pub enum AgendaKind {
-        Libs,
-        LibsAPI,
-        PGEH,
-    }
+#[derive(Clone, Debug, ValueEnum)]
+#[clap(rename_all = "verbatim")]
+pub enum AgendaKind {
+    Libs,
+    LibsAPI,
+    PGEH,
 }


### PR DESCRIPTION
`structopt` has been deprecated in favor of the derive macros built into the new versions of `clap`.

<br>

**Before:**

```console
$ cargo run -- --help
fully-automatic-rust-libs-team-triage-meeting-agenda-generator 0.1.0

USAGE:
    fully-automatic-rust-libs-team-triage-meeting-agenda-generator [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -a, --agenda <agenda>     [default: LibsAPI]  [possible values: Libs, LibsAPI, PGEH]
```

**After:**

```console
$ cargo run -- --help
Usage: fully-automatic-rust-libs-team-triage-meeting-agenda-generator [OPTIONS]

Options:
  -a, --agenda <AGENDA>  [default: LibsAPI] [possible values: Libs, LibsAPI, PGEH]
  -h, --help             Print help
```