### PR TITLE
Format agenda-generator with rustfmt

### DIFF
--- a/tools/agenda-generator/src/generator.rs
+++ b/tools/agenda-generator/src/generator.rs
@@ -337,7 +337,9 @@ impl Generator {
             for fcp in fcps {
                 let url = shorten(&format!(
                     "https://github.com/{}/issues/{}", //#issuecomment-{}",
-                    fcp.issue.repository, fcp.issue.number, // fcp.status_comment.id
+                    fcp.issue.repository,
+                    fcp.issue.number,
+                    // fcp.status_comment.id
                 ));
                 write!(
                     self.agenda,


### PR DESCRIPTION
Rustfmt is no longer satisfied with these being on one line since 397fd6aeb9754a12bf5915da5da41f7af115208e.