### PR TITLE
fix: Update ipcheck

### DIFF
--- a/tools/ipcheck/host/build/dotnet.rs
+++ b/tools/ipcheck/host/build/dotnet.rs
@@ -12,10 +12,12 @@ pub fn build() -> std::io::Result<&'static str> {
         "../artifacts/dotnet/IPCheck.csproj",
     )?;
 
-    let output = std::process::Command::new("dotnet").args(&["--version"]).output()?;
+    let output = std::process::Command::new("dotnet")
+        .args(&["--version"])
+        .output()?;
 
     if output.status.success() {
-        Ok("dotnet run -p ../artifacts/dotnet/IpCheck.csproj")
+        Ok("dotnet run --project ../artifacts/dotnet/IpCheck.csproj")
     } else {
         Err(std::io::Error::new(
             std::io::ErrorKind::Other,

--- a/tools/ipcheck/impls/dotnet/IPCheck.cs
+++ b/tools/ipcheck/impls/dotnet/IPCheck.cs
@@ -9,28 +9,62 @@ class IPCheck
         var input = args[0];
         var addr = IPAddress.Parse(input);
 
-        var data = new {
-            to_ipv4 = addr.MapToIPv4().ToString(),
-            to_ipv6 = addr.MapToIPv6().ToString(),
-            is_unspecified = "<unsupported>",
-            is_loopback = IPAddress.IsLoopback(addr),
-            is_reserved = "<unsupported>",
-            is_benchmarking = "<unsupported>",
-            is_documentation = "<unsupported>",
-            is_global = "<unsupported>",
-            is_shared = "<unsupported>",
-            is_unicast_link_local = addr.IsIPv6LinkLocal,
-            is_unique_local = "<unsupported>",
-            mc_scope_admin_local = "<unsupported>",
-            mc_scope_global = "<unsupported>",
-            mc_scope_iface_local = "<unsupported>",
-            mc_scope_link_local = "<unsupported>",
-            mc_scope_org_local = "<unsupported>",
-            mc_scope_realm_local = "<unsupported>",
-            mc_scope_reserved = "<unsupported>",
-            mc_scope_unassigned = "<unsupported>"
-        };
+        if (addr.AddressFamily == System.Net.Sockets.AddressFamily.InterNetwork)
+        {
 
-        Console.WriteLine("{0}", JsonSerializer.Serialize(data));
+            var data = new
+            {
+                to_ipv4 = addr.MapToIPv4().ToString(),
+                to_ipv6 = addr.MapToIPv6().ToString(),
+                is_unspecified = "<unsupported>",
+                is_loopback = IPAddress.IsLoopback(addr),
+                is_reserved = "<unsupported>",
+                is_benchmarking = "<unsupported>",
+                is_documentation = "<unsupported>",
+                is_global = "<unsupported>",
+                is_shared = "<unsupported>",
+                is_unicast_link_local = "<unsupported>",
+                is_unique_local = "<unsupported>",
+                mc_scope_admin_local = "<unsupported>",
+                mc_scope_global = "<unsupported>",
+                mc_scope_iface_local = "<unsupported>",
+                mc_scope_link_local = "<unsupported>",
+                mc_scope_org_local = "<unsupported>",
+                mc_scope_realm_local = "<unsupported>",
+                mc_scope_reserved = "<unsupported>",
+                mc_scope_unassigned = "<unsupported>"
+            };
+
+            Console.WriteLine("{0}", JsonSerializer.Serialize(data));
+        }
+        else
+        {
+
+            var data = new
+            {
+                to_ipv4 = addr.MapToIPv4().ToString(),
+                to_ipv6 = addr.MapToIPv6().ToString(),
+                is_unspecified = "<unsupported>",
+                is_loopback = IPAddress.IsLoopback(addr),
+                is_reserved = "<unsupported>",
+                is_benchmarking = "<unsupported>",
+                is_documentation = "<unsupported>",
+                is_global = "<unsupported>",
+                is_shared = "<unsupported>",
+                is_unicast_link_local = addr.IsIPv6LinkLocal,
+                is_unique_local = "<unsupported>",
+                mc_scope_admin_local = "<unsupported>",
+                mc_scope_global = "<unsupported>",
+                mc_scope_iface_local = "<unsupported>",
+                mc_scope_link_local = "<unsupported>",
+                mc_scope_org_local = "<unsupported>",
+                mc_scope_realm_local = "<unsupported>",
+                mc_scope_reserved = "<unsupported>",
+                mc_scope_unassigned = "<unsupported>"
+            };
+
+            Console.WriteLine("{0}", JsonSerializer.Serialize(data));
+        }
+
     }
 }

--- a/tools/ipcheck/impls/dotnet/IPCheck.csproj
+++ b/tools/ipcheck/impls/dotnet/IPCheck.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>9</LangVersion>
   </PropertyGroup>
 

--- a/tools/ipcheck/impls/rust_current/main.rs
+++ b/tools/ipcheck/impls/rust_current/main.rs
@@ -37,7 +37,7 @@ fn main() {
         "is_global": addr.is_global(),
         "is_unicast_link_local": match addr {
             IpAddr::V4(addr) => addr.is_link_local(),
-            IpAddr::V6(_) => false,
+            IpAddr::V6(addr) => addr.is_unicast_link_local(),
         },
         "is_unspecified": addr.is_unspecified(),
         "is_unique_local": match addr {


### PR DESCRIPTION
- Update .NET version to make it compile on my computer
- Correct use of .NETs  [IsIPv6UniqueLocal](https://learn.microsoft.com/en-us/dotnet/api/system.net.ipaddress.isipv6uniquelocal?view=net-8.0). It's actually unsupported on IPv4, previously it gave false positives.
- Include Rust's support for `is_unicast_link_local`

Differentes remain:
Go and Rust have different opinions on `is_global`.
One loopback address remains debated: Rust should also check if an IPv6 address is actually an IPv4 mapped to IPv6 and is loopback. 

Rust differentiates `unicast_link_local` and IPv4 to IPv6 mapped addresses that are link local (in IPv4 definition).