### PR TITLE
Use blank title for ACP issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/api-change-proposal.md
+++ b/.github/ISSUE_TEMPLATE/api-change-proposal.md
@@ -1,7 +1,7 @@
 ---
 name: API Change Proposal
 about: Propose a new API change to the libs-api team
-title: "(My API Change Proposal)"
+title: ''
 labels: api-change-proposal, T-libs-api
 assignees: ""
 ---


### PR DESCRIPTION
There's a near identical PR for compiler MCPs: https://github.com/rust-lang/compiler-team/pull/879

> To hopefully make it less likely for people to forget to change their MCP issue title.
>
> See [#t-compiler/major changes > Retroactive MCP for the Rust for Linux Ec… compiler-team#874 @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/233931-t-compiler.2Fmajor-changes/topic/Retroactive.20MCP.20for.20the.20Rust.20for.20Linux.20Ec.E2.80.A6.20compiler-team.23874/near/520992619)