### PR TITLE
Allow unauthenticated users to apply the `waiting-on-author` label

### DIFF
--- a/triagebot.toml
+++ b/triagebot.toml
@@ -20,6 +20,9 @@ allow-unauthenticated = [
     "initial-comment-period",
 ]
 
+# Enable rustbot ready/author/blocked shortcuts
+[shortcut]
+
 # [major-change]
 # second_label = "initial-comment-period"
 # meeting_label = "I-nominated"


### PR DESCRIPTION
Given that they can set pretty much all the other flags (including e.g. nominating an issue), adding/removing `waiting-on-author` fits in that workflow and so seems sensible to add.