### PR TITLE
Add missing `t-` prefix to the `S-waiting-on-{team}` labels

### DIFF
--- a/tools/agenda-generator/src/generator.rs
+++ b/tools/agenda-generator/src/generator.rs
@@ -68,7 +68,7 @@ impl Generator {
             .write(&mut self)?;
 
         GithubQuery::new("waiting on team")
-            .labels(&["S-waiting-on-libs-api"])
+            .labels(&["S-waiting-on-t-libs-api"])
             .repo("rust-lang/rust")
             .repo("rust-lang/rfcs")
             .write(&mut self)?;
@@ -156,7 +156,7 @@ impl Generator {
             .write(&mut self)?;
 
         GithubQuery::new("Waiting on team")
-            .labels(&["S-waiting-on-libs"])
+            .labels(&["S-waiting-on-t-libs"])
             .repo("rust-lang/rust")
             .write(&mut self)?;
 


### PR DESCRIPTION
Context: [#general > Team-based variant of &#96;S-waiting-on-team&#96; @ 💬](https://rust-lang.zulipchat.com/#narrow/channel/122651-general/topic/Team-based.20variant.20of.20.60S-waiting-on-team.60/near/543454067)

Follow up to https://github.com/rust-lang/libs-team/pull/671

cc @Amanieu 